### PR TITLE
Avoid infinity division expectedCycleDamagePerTurn

### DIFF
--- a/src/global_logic.js
+++ b/src/global_logic.js
@@ -580,7 +580,7 @@ module.exports.calcBasedOneSummon = function (summonind, prof, buff, totals) {
         
         var ougiGageUpOugiBuff = buff["ougiGageUpOugi"] * (buff["ougiGage"] + totals[key]["ougiGageBuff"] - totals[key]["ougiDebuff"]);
         var OugiGage = 100 - Math.min(99, ougiGageUpOugiBuff);
-        var minimumTurn = Math.min(9999, Math.ceil(OugiGage / (37.0 * (buff["ougiGage"] + totals[key]["ougiGageBuff"] - totals[key]["ougiDebuff"]))));
+        var minimumTurn = Math.ceil(OugiGage / (37.0 * (buff["ougiGage"] + totals[key]["ougiGageBuff"] - totals[key]["ougiDebuff"])));
         var expectedTurn = Math.min(OugiGage / expectedOugiGage, minimumTurn);
 
         // "additionalDamage" considers the Fourth Pursuit effect as a normal frame
@@ -665,6 +665,10 @@ module.exports.calcBasedOneSummon = function (summonind, prof, buff, totals) {
         // Ougi + chain burst (buff ["chainNumber"] is 1 or more so division OK)
         expectedCycleDamage += ougiDamage + chainBurst / buff["chainNumber"];
         var expectedCycleDamagePerTurn = expectedCycleDamage / (expectedTurn + 1.0);
+
+        if (expectedTurn === Infinity) {
+            expectedCycleDamagePerTurn = expectedAttack * damage;
+        }
         
         
         // Display array
@@ -2486,8 +2490,9 @@ module.exports.generateHaisuiData = function (res, arml, summon, prof, chara, st
 
                     var chainNumber = !isNaN(prof.chainNumber) ? parseInt(prof.chainNumber) : 1;
                     var newChainBurst = module.exports.calcChainBurst(chainNumber * newOugiDamage, chainNumber, module.exports.getTypeBonus(onedata[key].element, prof.enemyElement), onedata[key].skilldata.chainDamageUP, onedata[key].skilldata.chainDamageLimit) / chainNumber;
-                    var newExpectedCycleDamagePerTurn = (newChainBurst + newOugiDamage
-                        + onedata[key].expectedTurn * onedata[key].expectedAttack * newDamage) / (onedata[key].expectedTurn + 1);
+                    var newExpectedCycleDamagePerTurn = (onedata[key].expectedTurn === Infinity)
+                        ? (onedata[key].expectedAttack * newDamage)
+                        : (newChainBurst + newOugiDamage + onedata[key].expectedTurn * onedata[key].expectedAttack * newDamage) / (onedata[key].expectedTurn + 1);
 
                     var hp;
                     if (displayRealHP) {


### PR DESCRIPTION
In the Ougi gage -100% case, expectedTurn become infinity
then cycle turn damage had became NaN.

This approacha, when ougi not happen (expectedTurn was Infinity)
turn damage does not contain C.A and C.B damages.